### PR TITLE
Updated `NightVisionEffect` to follow new API for configuration dialog

### DIFF
--- a/NightVisionAddin/NightVisionExtension.cs
+++ b/NightVisionAddin/NightVisionExtension.cs
@@ -33,7 +33,7 @@ public sealed class NightVisionExtension : IExtension
 {
 	public void Initialize ()
 	{
-		PintaCore.Effects.RegisterEffect (new NightVisionEffect ());
+		PintaCore.Effects.RegisterEffect (new NightVisionEffect (PintaCore.Services));
 	}
 
 	public void Uninitialize ()


### PR DESCRIPTION
Part of addressing https://github.com/PintaProject/Pinta/pull/1264

Maybe, in the future, the chrome and workspace services should be refactored so that we can get rid of the `workspace` argument in `LaunchSimpleEffectDialog`?